### PR TITLE
一般用と管理者用のコンソールを異なるlambdaで実行する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,11 +36,13 @@ jobs:
         shell: bash
         env:
           DIR_PATH: ${{ format('lambda/{0}', fromJSON(steps.get_server_props.outputs.props)['lambda']['path']) }}
-          FUNCTION_NAME: ${{ fromJSON(steps.get_server_props.outputs.props)['lambda']['name'] }}
+          FUNCTION_NAME: ${{ fromJSON(steps.get_server_props.outputs.props)['lambda']['function_name'] }}
+          ADMIN_FUNCTION_NAME: ${{ fromJSON(steps.get_server_props.outputs.props)['lambda']['admin_function_name'] }}
           REGION: ${{ fromJSON(steps.get_server_props.outputs.props)['lambda']['region'] }}
         run: |
           echo "dir_path=${DIR_PATH}" >> "$GITHUB_OUTPUT"
           echo "function_name=${FUNCTION_NAME}" >> "$GITHUB_OUTPUT"
+          echo "admin_function_name=${ADMIN_FUNCTION_NAME}" >> "$GITHUB_OUTPUT"
           echo "region=${REGION}" >> "$GITHUB_OUTPUT"
 
       - name: Export Commit Hash
@@ -79,13 +81,31 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Update Lambda
+      - name: Install python libraries
+        shell: bash
+        working-directory: ${{ steps.lambda_props.outputs.dir_path }}
+        run: |
+          pip3 install awscli
+          pip3 install requests -t .
+
+      - name: Update Lambda for admin
+        shell: bash
+        working-directory: ${{ steps.lambda_props.outputs.dir_path }}
+        env:
+          FUNCTION_NAME: ${{ steps.lambda_props.outputs.admin_function_name }}
+        run: |
+          echo -n "admin" > ./res/txt/function_type.txt
+          rm -rf package.zip
+          zip -r package.zip ./*
+          aws lambda update-function-code --function-name "${FUNCTION_NAME}" --zip-file fileb://package.zip --publish
+
+      - name: Update Lambda for user
         shell: bash
         working-directory: ${{ steps.lambda_props.outputs.dir_path }}
         env:
           FUNCTION_NAME: ${{ steps.lambda_props.outputs.function_name }}
         run: |
-          pip3 install awscli
-          pip3 install requests -t .
+          echo -n "user" > ./res/txt/function_type.txt
+          rm -rf package.zip
           zip -r package.zip ./*
           aws lambda update-function-code --function-name "${FUNCTION_NAME}" --zip-file fileb://package.zip --publish

--- a/lambda/console_default/lambda_function.py
+++ b/lambda/console_default/lambda_function.py
@@ -113,6 +113,14 @@ def do_action(event):
             instance_type, max_user = [ (x['instance_type'], x['value']) for x in common_settings['capacities'] if str(x['value']) == capacity ][0]
             script_arg = mode
             update_plugins = get_param(event, 'update_plugins', 'false')
+
+            if len([ x for x in instance_describe.describe_action(name, [region])['instances'] if x['State'] x != 'stopped' ]) > 0:
+                return {
+                    'statusCode': 429,
+                    'headers': { 'Content-Type': 'text/json; charset=UTF-8' },
+                    'body': '{"message":"否定し状態のインスタンスが存在しています。"}',
+                }
+
             return {
                 'statusCode': 200,
                 'headers': { 'Content-Type': 'text/json; charset=UTF-8' },

--- a/lambda/console_default/lambda_function.py
+++ b/lambda/console_default/lambda_function.py
@@ -118,7 +118,7 @@ def do_action(event):
             script_arg = 'admin' if request_as_admin == 'true' else 'user'
             update_plugins = get_param(event, 'update_plugins', 'false')
 
-            if len([ x for x in instance_describe.describe_action(name, [region])['instances'] if x['State'] x != 'stopped' ]) > 0:
+            if len([ x for x in instance_describe.describe_action(name, [region])['instances'] if x['State'] != 'stopped' ]) > 0:
                 return {
                     'statusCode': 429,
                     'headers': { 'Content-Type': 'text/json; charset=UTF-8' },

--- a/lambda/console_default/main.html
+++ b/lambda/console_default/main.html
@@ -38,8 +38,7 @@
         </select>
         /*${{admin_update_plugins_check}}*/
         <input id="instance_id" type="hidden" name="instance_id" value=""><br>
-        <button id="start" onclick="Start(this)" type="submit" name="action" value="CreateInstance">起動する</button>
-        /*${{admin_button}}*/
+        <button id="start" onclick="Start(this)" type="submit" name="action" value="CreateInstance">/*${{create_instance_button_value}}*/</button>
     </form>
     <div id="result2"></div>
     <h2>アーカイブリスト</h2>

--- a/lambda/console_default/main.html
+++ b/lambda/console_default/main.html
@@ -37,8 +37,10 @@
             /*${{user_capacity}}*/
         </select>
         /*${{admin_update_plugins_check}}*/
+        <input id="request_as_admin" type="hidden" name="request_as_admin" value="false"><br>
         <input id="instance_id" type="hidden" name="instance_id" value=""><br>
-        <button id="start" onclick="Start(this)" type="submit" name="action" value="CreateInstance">/*${{create_instance_button_value}}*/</button>
+        <button id="start" onclick="Start(this)" type="submit" name="action" value="CreateInstance">起動する</button>
+        /*${{admin_create_instance_button}}*/
     </form>
     <div id="result2"></div>
     <h2>アーカイブリスト</h2>

--- a/lambda/console_default/script.js
+++ b/lambda/console_default/script.js
@@ -148,10 +148,11 @@ function RedirectInstancePage(publicIpAddress) {
     });
 }
 
-function Start(sender) {
+function Start(sender, request_as_admin = false) {
     UpdateStartButton(true);
     document.querySelector("#result2").innerHTML = '<p>インスタンス作成中...<div class="loader"></div></p>';
     document.querySelector("#parameter-form > #instance_id").removeAttribute("value");
+    document.querySelector("#parameter-form > #request_as_admin").setAttribute("value", request_as_admin);
     XMLHttpRequestSubmit(sender).then((xhr) => {
         let div = document.querySelector("#result2");
         if (xhr.readyState == 4 && xhr.status == 200) {
@@ -169,6 +170,7 @@ function SyncInstanceRuning(sender, instanceId) {
     document.querySelector("#result2").innerHTML = '<p>インスタンス起動中...<div class="loader"></div></p>';
     sender.setAttribute("value", "SyncInstanceRuning");
     document.querySelector("#parameter-form > #instance_id").setAttribute("value", instanceId);
+    document.querySelector("#parameter-form > #request_as_admin").setAttribute("value", false);
     setTimeout(function() {
         XMLHttpRequestSubmit(sender).then((xhr) => {
             let div = document.querySelector("#result2");

--- a/template/server_settings.json.template
+++ b/template/server_settings.json.template
@@ -54,7 +54,8 @@
       "prop_name": "dev",
       "lambda": {
         "path": "test",
-        "name": "dev_minecraft_server_manager",
+        "function_name": "dev_minecraft_server_manager_for_user",
+        "admin_function_name": "dev_minecraft_server_manager_for_admin",
         "region": "ap-northeast-1"
       },
       "server": {
@@ -67,7 +68,8 @@
       "prop_name": "prod",
       "lambda": {
         "path": "console_default",
-        "name": "prod_minecraft_server_manager",
+        "function_name": "prod_minecraft_server_manager_for_user",
+        "admin_function_name": "prod_minecraft_server_manager_for_admin",
         "region": "ap-northeast-1"
       },
       "server": {


### PR DESCRIPTION
Fix #11 

一般ユーザーでもクエリパラメータをいじって管理者用の機能を実行できてしまっていたので、lambdaごと分けて一般ユーザー用のlambdaでは一般ユーザー用の処理しか実行できないように変更した