### PR TITLE
インスタンス起動時のcloneでsparse blobless checkoutを実施する

### DIFF
--- a/lambda/console_default/res/bash/user_data.sh
+++ b/lambda/console_default/res/bash/user_data.sh
@@ -7,7 +7,12 @@ unzip -q awscliv2.zip
 rm -rf ./awscliv2.zip ./aws
 sudo -u ubuntu mkdir -p /home/ubuntu/workspace
 cd /home/ubuntu/workspace
-sudo -u ubuntu git clone --branch %%BRANCH_NAME%% https://github.com/Hiro-Onozawa/minecraft-server-manager.git user_util
+sudo -u ubuntu git clone --filter=blob:none --sparse --no-checkout --branch %%BRANCH_NAME%% https://github.com/Hiro-Onozawa/minecraft-server-manager.git user_util
+pushd user_util
+sudo -u ubuntu git sparse-checkout set
+sudo -u ubuntu git sparse-checkout add bash systemd template
+sudo -u ubuntu git checkout
+popd
 sudo -u ubuntu mkdir -p /home/ubuntu/workspace/user_util/settings
 cat << EOS > /home/ubuntu/workspace/user_util/settings/instance_parameters.json
 %%INSTANCE_PARAMS_JSON%%


### PR DESCRIPTION
FIX #16 

履歴はいらないのでblobless checkoutを行うことでDL量を削減する
lambdaや.githubなど一部のディレクトリのファイルは不要なのでsparse checkoutを行うことでDL量を削減する